### PR TITLE
Updated RSAT tool installation to use native installation process

### DIFF
--- a/Ansible/roles/install_rsat_tools/tasks/main.yml
+++ b/Ansible/roles/install_rsat_tools/tasks/main.yml
@@ -3,29 +3,12 @@
 # Description: Installs RSAT tools for Windows from a ZIP file
 
 
-
-- name: Create temp directory
-  win_file:
-    path: C:\Windows\temp
-    state: directory
-
 - name: Copy PowerShell script to enable Windows Update service
   win_copy:
     content: |
       Set-Service -Name wuauserv -StartupType Manual
       Start-Service -Name wuauserv
     dest: C:\Windows\temp\enable_windows_update.ps1
-
-- name: Upload RSAT ZIP file
-  win_copy:
-    src: files/WindowsTH-KB2693643-x64-win10.zip
-    dest: C:\Windows\temp\WindowsTH-KB2693643-x64-win10.zip
-
-- name: Extract ZIP file
-  win_unzip:
-    src: C:\Windows\temp\WindowsTH-KB2693643-x64-win10.zip
-    dest: C:\Windows\temp\
-    delete_archive: no
 
 - name: Enable Windows Update service
   win_shell: C:\Windows\temp\enable_windows_update.ps1
@@ -37,59 +20,42 @@
     name: wuauserv
     state: started
 
-#- name: Install RSAT from .msu package
-  #win_shell: cmd.exe /c wusa.exe C:\Windows\temp\WindowsTH-KB2693643-x64.msu /quiet
-  #win_shell: wusa.exe C:\Windows\temp\WindowsTH-KB2693643-x64.msu /quiet /norestart /log:C:\Windows\temp\rsat_install.log 
-  #win_shell: wusa.exe C:\Windows\temp\WindowsTH-KB2693643-x64.msu /quiet /norestart /log:C:\Windows\temp\rsat_install.log & powershell Start-Service -Name WinRM
-  #vars:
-  #  ansible_become: true
-  #  ansible_become_method: runas
-  #  ansible_become_user: '.\localuser'
-  #  ansible_become_password: 'password'
-  #  ansible_become_flags: "logon_type=interactive logon_flags=with_profile"
-  #async: 120  # 2 minutes (120 seconds)
-  #poll: 10    # Check every 10 seconds
-  #register: install_task
-  #ignore_errors: yes  # Continue even if there's an error
+- name: Display Windows edition
+  debug:
+    var: ansible_os_product_type
 
-  ## Adding reboot command because the rsat install will stop the winrm service which is needed by ansible 
+- block:
+  - name: Install RSAT Tools with PowerShell (Server)
+    ansible.windows.win_feature:
+      name: RSAT-AD-PowerShell
+      state: present
+    vars:
+      ansible_become: true
+      ansible_become_method: runas
+      ansible_become_user: '.\localuser'
+      ansible_become_password: 'password'
+      ansible_become_flags: "logon_type=interactive logon_flags=netcredentials_only"
+    #async: 120
+    #poll: 0
+    register: win_feature
+  
+  - name: Reboot if installing RSAT feature requires it
+    ansible.windows.win_reboot:
+    when: win_feature.reboot_required
+  when: ansible_os_product_type is search("server")
 
-- name: Copy PowerShell script to install rsat, then restart the system to start the winrmservice 
-  win_copy:
-    content: |
-
-      Start-Process -FilePath "wusa.exe" -ArgumentList "C:\Windows\temp\WindowsTH-KB2693643-x64.msu /quiet /log:C:\Windows\temp\rsat_install.log" -Wait
-
-      # Then reboot after installation completes
-      Restart-Computer -Force
-
-    
-    dest: C:\Windows\temp\install_rsat.ps1
-
-
-
-- name: Install RSAT from .msu package
-  win_shell: |
-
-    C:\Windows\temp\install_rsat.ps1
-
-  vars:
-    ansible_become: true
-    ansible_become_method: runas
-    ansible_become_user: '.\localuser'
-    ansible_become_password: 'password'
-    ansible_become_flags: "logon_type=interactive logon_flags=with_profile"
-  async: 120
-  poll: 0
-  ignore_errors: yes
-
- #Wait for 5 minutes (300 seconds) after reboot, winrm takes a couple minutes to wake up 
-- name: Wait for 5 minutes
-  pause:
-    seconds: 420
-
-
-
+- block:
+  - name: Install RSAT Tools with PowerShell (Workstation)
+    ansible.windows.win_powershell:
+      script: |
+        Get-WindowsCapability -Name Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0 -Online | Add-WindowsCapability -Online
+    vars:
+     ansible_become: true
+     ansible_become_method: runas
+     ansible_become_user: '.\localuser'
+     ansible_become_password: 'password'
+     ansible_become_flags: "logon_type=interactive logon_flags=netcredentials_only"
+  when: ansible_os_product_type is search("workstation")
 
 - name: Clean up temporary files
   win_file:


### PR DESCRIPTION
* Fix for Issue #7 *

Changed the RSAT tool installation to use:
- ansible.windows.win_feature for Windows Servers
- ansible.windows.win_powershell for Windows Workstations

Tested with and without post installation reboot and it worked the exact same; the logical conclusion is that a reboot is not required.

Other notes: these lines seemed to cause issues during the Windows Server RSAT installation and were commented out. They can likely be deleted:
 ```
   #async: 120
   #poll: 0
```